### PR TITLE
Move link to video higher on incompatibility screen

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -16,6 +16,9 @@
             <h3 class="hadcrut4logo">Global Temperature</h3>
         </div>
         <h3>Incompatible browser</h3>
+        <p>
+            Click to see a <a href="https://www.youtube.com/watch?v=DAeak8YuG-c">video of the visualisation</a>. Alternatively you can <a id='goWithNotCompatible' href='#'>proceed anyway</a>.
+        </p>
         <div class="infotext">
             <p>This prototype visualisation requires a number of new and experimental browser features
                 which only work with certain modern browsers in the desktop environment.</p>
@@ -26,9 +29,6 @@
                 <li>Safari (Desktop) >= 9</li>
             </ul>
         </div>
-        <p>
-            Click to see a <a href="https://www.youtube.com/watch?v=DAeak8YuG-c">video of the visualisation</a>. Alternatively you can <a id='goWithNotCompatible' href='#'>proceed anyway</a>.
-        </p>
     </div>
 </div>
 


### PR DESCRIPTION
Comms have asked for the link to the video to be placed higher. Like so:

![image](https://cloud.githubusercontent.com/assets/1610850/20214926/0ab0ac40-a809-11e6-86e5-3e50045399dc.png)
